### PR TITLE
Change how enable/disable config param is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or install it yourself as:
 
 Look for `Kaminari::MandatoryOrdering::Error` exceptions, add order clauses to queries causing them.
 
-Can be enabled / disabled by setting `mandatory_ordering` option in `kaminari` configuration (defaults to `true`).
+Can be enabled / disabled by changing  `Kaminari::MandatoryOrdering.enabled` value (defaults to `true`).
 
 ## Development
 

--- a/kaminari-mandatory_ordering.gemspec
+++ b/kaminari-mandatory_ordering.gemspec
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'kaminari/mandatory_ordering/version'
@@ -18,9 +16,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'kaminari', '>= 1.0'
   spec.add_dependency 'activerecord', '>= 4.2'
   spec.add_dependency 'activesupport', '>= 4.2'
+  spec.add_dependency 'kaminari', '>= 1.0'
 
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/kaminari/mandatory_ordering.rb
+++ b/lib/kaminari/mandatory_ordering.rb
@@ -1,9 +1,20 @@
-require 'kaminari/mandatory_ordering/version'
 require 'active_support/lazy_load_hooks'
 
+module Kaminari
+  module MandatoryOrdering
+    require_relative './mandatory_ordering/version'
+    require_relative './mandatory_ordering/error'
+    require_relative './mandatory_ordering/active_record_extension'
+    require_relative './mandatory_ordering/active_record_model_extension'
+
+    class << self
+      attr_accessor :enabled
+    end
+  end
+end
+
+Kaminari::MandatoryOrdering.enabled = true
+
 ActiveSupport.on_load :active_record do
-  require 'kaminari/mandatory_ordering/error'
-  require 'kaminari/mandatory_ordering/active_record_extension'
-  require 'kaminari/mandatory_ordering/configuration'
   ::ActiveRecord::Base.send :include, Kaminari::MandatoryOrdering::ActiveRecordExtension
 end

--- a/lib/kaminari/mandatory_ordering/active_record_extension.rb
+++ b/lib/kaminari/mandatory_ordering/active_record_extension.rb
@@ -1,5 +1,3 @@
-require 'kaminari/mandatory_ordering/active_record_model_extension'
-
 module Kaminari
   module MandatoryOrdering
     module ActiveRecordExtension
@@ -11,7 +9,7 @@ module Kaminari
         end
       end
 
-      module ClassMethods
+      class_methods do
         def inherited(klass)
           super
           klass.send(:include, Kaminari::MandatoryOrdering::ActiveRecordModelExtension) if klass.superclass == ::ActiveRecord::Base

--- a/lib/kaminari/mandatory_ordering/active_record_model_extension.rb
+++ b/lib/kaminari/mandatory_ordering/active_record_model_extension.rb
@@ -3,7 +3,7 @@ module Kaminari
     module ActiveRecordModelExtension
       extend ActiveSupport::Concern
       included do |base|
-        if Kaminari.config.mandatory_ordering
+        if Kaminari::MandatoryOrdering.enabled
           orig = base.method(Kaminari.config.page_method_name)
           base.define_singleton_method(Kaminari.config.page_method_name) do |num = nil|
             if all.values.fetch(:order, []).none?

--- a/lib/kaminari/mandatory_ordering/configuration.rb
+++ b/lib/kaminari/mandatory_ordering/configuration.rb
@@ -1,3 +1,0 @@
-Kaminari.config.instance_eval do
-  self.mandatory_ordering = true
-end

--- a/lib/kaminari/mandatory_ordering/version.rb
+++ b/lib/kaminari/mandatory_ordering/version.rb
@@ -1,5 +1,5 @@
 module Kaminari
   module MandatoryOrdering
-    VERSION = '0.2.1'.freeze
+    VERSION = '0.3.0'.freeze
   end
 end

--- a/spec/kaminari/mandatory_ordering_spec.rb
+++ b/spec/kaminari/mandatory_ordering_spec.rb
@@ -40,9 +40,9 @@ describe Kaminari::MandatoryOrdering do
 
   context 'when disabled' do
     around(:each) do |example|
-      Kaminari.configure { |config| config.mandatory_ordering = false }
+      Kaminari::MandatoryOrdering.enabled = false
       example.run
-      Kaminari.configure { |config| config.mandatory_ordering = true }
+      Kaminari::MandatoryOrdering.enabled = true
     end
 
     it 'should not raise error when paging unordered collection' do


### PR DESCRIPTION
Latest kaminari (1.1.1) version does not allow to assign new values to Kaminari::Config object. These changes moves enable/disable flag to Kaminari::MandatoryOrdering module